### PR TITLE
Add AudioLink support

### DIFF
--- a/Assets/FuncWorld/Code/Compiler.cs
+++ b/Assets/FuncWorld/Code/Compiler.cs
@@ -6,6 +6,7 @@ using VRC.Udon;
 using VRC.Udon.Common;
 using UnityEngine.UI;
 
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
 public class Compiler : UdonSharpBehaviour
 {
     // TODO:
@@ -211,6 +212,18 @@ public class Compiler : UdonSharpBehaviour
             case "video":      return 47;
             case "all":        return 48;
             case "any":        return 49;
+            // AudioLink Extension
+            case "audiolinkgetversion": return 65;
+            case "audiolinkdata": return 66;
+            case "audiolinkdatamultiline": return 67;
+            case "audiolinklerp": return 68;
+            case "audiolinklerpmultiline": return 69;
+            case "audiolinkdecodedataasseconds": return 70;
+            case "audiolinkgetamplitudeatfrequency": return 71;
+            case "audiolinkgetamplitudeatnote": return 72;
+            case "audiolinkgetchronotime": return 73;
+            case "audiolinkgetchronotimenormalized": return 74;
+            case "audiolinkgetchronotimeinterval": return 75;
             default:           return 0;
         }
     }
@@ -586,6 +599,18 @@ public class Compiler : UdonSharpBehaviour
             case 47: return 1;
             case 48: return 1;
             case 49: return 1;
+            // AudioLink Extension
+            case 65: return 0;
+            case 66: return 1;
+            case 67: return 1;
+            case 68: return 1;
+            case 69: return 1;
+            case 70: return 1;
+            case 71: return 1;
+            case 72: return 2;
+            case 73: return 2;
+            case 74: return 3;
+            case 75: return 4;
             default:
                 for (int i = 0; i < funcIdents.Length; i++)
                 {

--- a/Assets/FuncWorld/Code/VM.shader
+++ b/Assets/FuncWorld/Code/VM.shader
@@ -13,6 +13,7 @@
         Pass
         {
             CGPROGRAM
+            #define AUDIOLINK
             #include "UnityCustomRenderTexture.cginc"
             #include "VM.cginc"
             #pragma vertex CustomRenderTextureVertexShader


### PR DESCRIPTION
Hi there,

I made some changes on the VM and the compiler in order to support AudioLink.

It adopts functions from AudioLink.cginc, so it do needs to import AudioLink as well to make it works. Also, I have defined a flag (`AUDIOLINK`) within the VM shader to toggle the extension off so it still can be used when there is no AudioLink and the flag removed.

The functions I have implemented with function ID are listed here:
- `AudioLinkGetVersion()`: 65
- `AudioLinkData(xy)`: 66
- `AudioLinkDataMultiline(xy)`: 67
- `AudioLinkLerp(xy)`: 68
- `AudioLinkLerpMultiline(xy)`: 69
- `AudioLinkDecodeDataAsSeconds(xy)`: 70
- `AudioLinkGetAmplitudeAtFrequency(hertz)`: 71
- `AudioLinkGetAmplitudeAtNote(oative, note)`: 72
- `AudioLinkGetChronoTime(index, band)`: 73
- `AudioLinkGetChronoTimeNormalized(index, band, speed)`: 74
- `AudioLinkGetChronoTimeInterval(index, band, speed, interval)`: 75

Usage of these functions are the same as original as I just calling them directly.
Functions not listed above are not implemented.

Because I don't know if there is any plan to use the function ID after 49, so I define these extended function ID start from 65.